### PR TITLE
use RAII for the resize locks

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -757,16 +757,6 @@ u32 InventoryList::moveItem(u32 i, InventoryList *dest, u32 dest_i,
 	return (oldcount - item1.count);
 }
 
-void InventoryList::checkResizeLock()
-{
-	if (!m_resize_lock)
-		return; // OK
-
-	throw BaseException("InventoryList '" + m_name + "' is currently"
-			" in use and cannot be deleted or resized.");
-}
-
-
 /*
 	Inventory
 */

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "exceptions.h"
 #include "itemdef.h"
 #include "irrlichttypes.h"
 #include "itemstackmetadata.h"
@@ -277,8 +278,28 @@ public:
 
 	inline bool checkModified() const { return m_dirty; }
 	inline void setModified(bool dirty = true) { m_dirty = dirty; }
-	inline void checkResizeLock();
-	inline void setResizeLock(bool status) { m_resize_lock = status; }
+
+	struct ResizeUnlocker {
+		void operator()(InventoryList *invlist)
+		{
+			invlist->m_resize_locks -= 1;;
+		}
+	};
+	using ResizeLocked = std::unique_ptr<InventoryList, ResizeUnlocker>;
+
+	inline void checkResizeLock()
+	{
+		if (m_resize_locks == 0)
+			return; // OK
+
+		throw BaseException("InventoryList '" + m_name
+				+ "' is currently in use and cannot be deleted or resized.");
+	}
+	inline ResizeLocked resizeLock()
+	{
+		m_resize_locks += 1;
+		return ResizeLocked(this);
+	}
 
 private:
 	std::vector<ItemStack> m_items;
@@ -287,7 +308,7 @@ private:
 	u32 m_width = 0;
 	IItemDefManager *m_itemdef;
 	bool m_dirty = true;
-	bool m_resize_lock = false; // Lua callback sanity
+	u32 m_resize_locks = 0; // Lua callback sanity
 };
 
 class Inventory

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -278,8 +278,8 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		return;
 	}
 
-	mgr->lockList(list_from);
-	mgr->lockList(list_to);
+	auto list_from_lock = list_from->resizeLock();
+	auto list_to_lock = list_to->resizeLock();
 
 	if (move_somewhere) {
 		s16 old_to_i = to_i;
@@ -573,7 +573,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 	/*
 		Report move to endpoints
 	*/
-	list_to->setResizeLock(false);
+	list_to_lock.reset();
 
 	// Source = destination => move
 	if (from_inv == to_inv) {
@@ -687,7 +687,7 @@ void IDropAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		return;
 	}
 
-	mgr->lockList(list_from);
+	auto list_from_lock = list_from->resizeLock();
 
 	/*
 		Do not handle rollback if inventory is player's
@@ -769,7 +769,7 @@ void IDropAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 	/*
 		Report drop to endpoints
 	*/
-	list_from->setResizeLock(false);
+	list_from_lock.reset();
 
 	switch (from_inv.type) {
 	case InventoryLocation::DETACHED:
@@ -886,9 +886,9 @@ void ICraftAction::apply(InventoryManager *mgr,
 		return;
 	}
 
-	mgr->lockList(list_craft);
-	mgr->lockList(list_craftresult);
-	mgr->lockList(list_main);
+	auto list_craft_lock       = list_craft->resizeLock();
+	auto list_craftresult_lock = list_craftresult->resizeLock();
+	auto list_main_lock        = list_main->resizeLock();
 
 	ItemStack crafted;
 	ItemStack craftresultitem;

--- a/src/inventorymanager.h
+++ b/src/inventorymanager.h
@@ -114,9 +114,6 @@ public:
 	virtual void setInventoryModified(const InventoryLocation &loc) {}
     // Send inventory action to server (only on client)
 	virtual void inventoryAction(InventoryAction *a){}
-	// To prevent the Lua API from resizig or deleting lists that are in use
-	virtual void lockList(InventoryList *list) {}
-	virtual void unlockLists() {}
 };
 
 enum class IAction : u16 {

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -746,15 +746,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 	}
 
 	// Do the action
-	try {
-		a->apply(m_inventory_mgr.get(), playersao, this);
-		m_inventory_mgr.get()->unlockLists();
-	} catch (BaseException &e) {
-		// make sure the lists are unlocked prior attempting to free them
-		m_inventory_mgr.get()->unlockLists();
-		// rethrow to handle by Lua
-		throw LuaError(e.what());
-	}
+	a->apply(m_inventory_mgr.get(), playersao, this);
 }
 
 void Server::handleCommand_ChatMessage(NetworkPacket* pkt)

--- a/src/server/serverinventorymgr.cpp
+++ b/src/server/serverinventorymgr.cpp
@@ -107,20 +107,6 @@ void ServerInventoryManager::setInventoryModified(const InventoryLocation &loc)
 	}
 }
 
-void ServerInventoryManager::lockList(InventoryList *list)
-{
-	m_locked_lists.insert(list);
-	list->setResizeLock(true);
-}
-
-void ServerInventoryManager::unlockLists()
-{
-	for (auto list : m_locked_lists)
-		list->setResizeLock(false);
-
-	m_locked_lists.clear();
-}
-
 Inventory *ServerInventoryManager::createDetachedInventory(
 		const std::string &name, IItemDefManager *idef, const std::string &player)
 {

--- a/src/server/serverinventorymgr.h
+++ b/src/server/serverinventorymgr.h
@@ -39,9 +39,6 @@ public:
 	Inventory *getInventory(const InventoryLocation &loc);
 	void setInventoryModified(const InventoryLocation &loc);
 
-	void lockList(InventoryList *list);
-	void unlockLists();
-
 	// Creates or resets inventory
 	Inventory *createDetachedInventory(const std::string &name, IItemDefManager *idef,
 			const std::string &player = "");
@@ -60,6 +57,5 @@ private:
 
 	ServerEnvironment *m_env = nullptr;
 
-	std::set<InventoryList *> m_locked_lists;
 	std::unordered_map<std::string, DetachedInventory> m_detached_inventories;
 };


### PR DESCRIPTION
See `inventory.h`.
* Gives automatic exception safety, so no need to catch and rethrow.
* No need for the set of locked lists in invmgr.
* Counting lock makes sure we get no issues when we lock the same list twice and incorrectly unlock too early (e.g. when `list_from == list_to`).

(Also moved `checkResizeLock()` into header for inlining (it had already compiled successfully without including the exceptions header, so extra include doesn't matter, because dependers already included it).)